### PR TITLE
修改严格模式不兼容问题

### DIFF
--- a/js/basic/tools/original.js
+++ b/js/basic/tools/original.js
@@ -1,5 +1,5 @@
-'use strict';
 define(function(require) {
+  	'use strict';
 	var $ = require('lib/jquery'),
 		config = require('spreadsheet/config'),
 		binary = require('basic/util/binary'),


### PR DESCRIPTION
在chrome<48版本的情况下，‘use strcit’需要改成内部代码检查
