### PR TITLE
滚动操作，行与单元格的请求为异步操作

### DIFF
--- a/js/basic/util/observer.pattern.js
+++ b/js/basic/util/observer.pattern.js
@@ -9,7 +9,8 @@ define(function() {
 
 	/**
 	 * 订阅者列表
-	 * 将订阅者作为公共变量,类似cache
+	 * 将订阅者作为公共变量,类似cache,
+	 * 订阅者订阅事件时,不需要含有发布者的引用
 	 * @type {Object}
 	 */
 	subscribers = {};
@@ -52,9 +53,14 @@ define(function() {
 			unsubscribe: function(publisherName, type) {
 				var currentSubscribers,
 					currentSubscriber,
+					types,
 					max, i;
 
-				currentSubscribers = subscribers[publisherName];
+				types = subscribers[publisherName];
+				if (types === undefined) {
+					return;
+				}
+				currentSubscribers = types[type];
 				max = currentSubscribers !== undefined ? currentSubscribers.length : 0;
 				for (i = 0; i < max; i++) {
 					currentSubscriber = currentSubscribers[i];
@@ -109,6 +115,9 @@ define(function() {
 					obj[i] = this.subscriber[i];
 				}
 			}
+		},
+		clearSubscriber: function() {
+			subscribers = {};
 		}
 	};
 	return observer;

--- a/js/basic/util/observer.pattern.js
+++ b/js/basic/util/observer.pattern.js
@@ -1,64 +1,95 @@
 'use strict';
 define(function() {
 	/**
-	 * 订阅模式装饰类
-	 * 系统配置变量
-	 * @author ray wu
-	 * @class observer
-	 * @since 0.1.0
-	 * @module basic
+	 * 订阅模式模块
 	 */
-	var observer = {
+
+	var observer,
+		subscribers;
+
+	/**
+	 * 订阅者列表
+	 * 将订阅者作为公共变量,类似cache的缓存
+	 * @type {Object}
+	 */
+	subscribers = {};
+
+	/**
+	 * 订阅模式装饰类
+	 * @type {Object}
+	 */
+	observer = {
 		/**
-		 * 发布器
+		 * 订阅者
+		 * @type {Object}
+		 */
+		subscriber: {
+			/**
+			 * 订阅类型
+			 * @param  {function} fn     	订阅回调函数   
+			 * @param  {string}   publisher 订阅者标识
+			 * @param  {string}   type      订阅类型
+			 */
+			subscribe: function(publisher, type, fn) {
+				var temp1,
+					temp2;
+				if (typeof(temp1 = subscribers[publisher]) === 'undefined') {
+					temp1 = subscribers[publisher] = {};
+				}
+				if (typeof(temp2 = temp1[type]) === 'undefined') {
+					temp2 = temp1[type] = [];
+				}
+				temp2.push({
+					fn: fn,
+					context: this
+				});
+			},
+			/**
+			 * 取消订阅
+			 * @param  {function} fn     	订阅回调函数   
+			 * @param  {string}   publisher 订阅者标识
+			 * @param  {string}   type      订阅类型
+			 */
+			unsubscribe: function(publisher, type, fn) {
+				var currentSubscribers,
+					currentSubscriber,
+					max, i;
+
+				currentSubscribers = subscribers[publisher];
+				max = currentSubscribers !== undefined ? currentSubscribers.length : 0;
+				for (i = 0; i < max; i++) {
+					currentSubscriber = currentSubscribers[i];
+					if (currentSubscriber.fn === fn && currentSubscriber.context === this) {
+						currentSubscribers.splice(i, 1);
+					}
+				}
+			},
+		},
+		/**
+		 * 发布者
 		 * @property {object} publisher
 		 */
 		publisher: {
-			subscribers: {
-				any: [] //事件类型：订阅者（subscribers）
-			},
-			subscribe: function(fn, type) {
-				type = type || 'any';
-				if (typeof this.subscribers[type] === 'undefined') {
-					this.subscribers[type] = [];
-				}
-				this.subscribers[type].push(fn);
-			},
-			unsubscribe: function(fn, type) {
-				this.visitSubscribers('unsubscribe', fn, type);
-			},
-			publish: function(publication, type) {
-				this.visitSubscribers('publish', publication, type);
-			},
 			/**
-			 * 订阅者触发动作
-			 * @method visitSubscribers 
-			 * @param  {string} action 发布护着取消订阅
-			 * @param  {object} arg    传递发布的内容
-			 * @param  {string} type   订阅的类型
+			 * 发布
+			 * @param  {string} name 发布者标识
+			 * @param  {string} type 发布类型
 			 */
-			visitSubscribers: function(action, arg, type) {
-				var pubtype = type || 'any',
-					subscribers = this.subscribers[pubtype],
-					subscriber,
-					i,
-					max;
-				max = subscribers !== undefined ? subscribers.length : 0;
-				for (i = 0; i < max; i++) {
-					if (action === 'publish') {
-						subscriber = subscribers[i];
-						if(typeof subscriber === 'object'){
-							subscriber.master[subscriber.behavior](arg, subscriber.args);
-						}else if(typeof subscriber === 'function'){
-							subscriber(arg);
-						}
-					} else {
-						if (subscribers[i] === arg) {
-							subscribers.splice(i, 1);
-						}
+			publish: function(name, type) {
+				var currentSubscribers,
+					currentSubscriber,
+					max, i, callback;
+
+				currentSubscribers = subscribers[name];
+				if (currentSubscribers !== undefined &&
+					(currentSubscribers = currentSubscribers[type]) !== undefined) {
+					max = currentSubscribers !== undefined ? currentSubscribers.length : 0;
+					for (i = 0; i < max; i++) {
+						currentSubscriber = currentSubscribers[i];
+						currentSubscriber.context[currentSubscriber.fn]([].slice.call(arguments, 2));
 					}
 				}
-			}
+			},
 		},
 		/**
 		 * 建立发布者
@@ -71,9 +102,13 @@ define(function() {
 					obj[i] = this.publisher[i];
 				}
 			}
-			obj.subscribers = {
-				any: []
-			};
+		},
+		buildSubscriber: function(obj) {
+			for (var i in this.subscriber) {
+				if (this.subscriber.hasOwnProperty(i) && typeof this.subscriber[i] === 'function') {
+					obj[i] = this.subscriber[i];
+				}
+			}
 		}
 	};
 	return observer;

--- a/js/views/bodyContainer.js
+++ b/js/views/bodyContainer.js
@@ -171,10 +171,12 @@ define(function(require) {
 				mainContainer;
 
 			this.clearFrozenRule();
+
 			this.ruleRow();
 			this.ruleCol();
 			this.ruleMain();
-
+			observerPattern.clearSubscriber();
+			
 			// destory old view
 			Backbone.trigger('event:colsPanelContainer:destroy');
 			Backbone.trigger('event:rowsPanelContainer:destroy');

--- a/js/views/bodyContainer.js
+++ b/js/views/bodyContainer.js
@@ -400,7 +400,9 @@ define(function(require) {
 					publisherName: 'mainContainer',
 					behavior: 'scrollToPosition', //it's self behavior
 					action: 'verticalPublish' //publisher behavior
-				}, {
+				}, 
+				
+				{
 					publisherName: 'mainContainer',
 					behavior: 'addHeadItemView', //it's self behavior
 					action: 'addRowHeadItemViewPublish' //publisher behavior
@@ -408,7 +410,9 @@ define(function(require) {
 					publisherName: 'mainContainer',
 					behavior: 'adjustHeadItemContainer', //it's self behavior
 					action: 'adjustHeadItemContainerPublish' //publisher behavior
-				}]
+				}
+
+				]
 			};
 			if (cache.TempProp.isFrozen && cache.TempProp.rowFrozen) {
 				tempRule.displayPosition.offsetTop -= userViewModel.get('top');

--- a/js/views/bodyContainer.js
+++ b/js/views/bodyContainer.js
@@ -57,14 +57,15 @@ define(function(require) {
 		 * @chainable
 		 */
 		render: function() {
+			var inputContainer = new InputContainer();
+
+			observerPattern.buildSubscriber(inputContainer);
+			inputContainer.subscribe('mainContainer', 'transversePublish', 'transverseScroll');
+			inputContainer.subscribe('mainContainer', 'verticalPublish', 'verticalScroll');
+
 			this.$el.html(getTemplate('BODYTEMPLATE'));
-			this.inputContainer = new InputContainer();
-			observerPattern.buildSubscriber(this.inputContainer);
+			this.$el.find('.main-layout').append(inputContainer.render().el);
 
-			this.inputContainer.subscribe('mainContainer', 'transversePublish', 'transverseScroll');
-			this.inputContainer.subscribe('mainContainer', 'verticalPublish', 'verticalScroll');
-
-			this.$el.find('.main-layout').append(this.inputContainer.render().el);
 			this.calculation();
 			this.adaptScreen();
 			this.generateSheet();
@@ -72,7 +73,7 @@ define(function(require) {
 				'overflow': 'hidden',
 				'position': 'relative'
 			});
-			this.inputContainer.$el.focus();
+			inputContainer.$el.focus();
 		},
 		handleComment: function(options) {
 			var action = options.action,
@@ -86,7 +87,6 @@ define(function(require) {
 				this.$el.find('.main-layout').append(commentContainer.render().el);
 				commentContainer.subscribe('mainContainer', 'transversePublish', 'transverseScroll');
 				commentContainer.subscribe('mainContainer', 'verticalPublish', 'verticalScroll');
-
 			}
 			if (action === 'hide') {
 				this.commentContainer.hide();
@@ -174,7 +174,7 @@ define(function(require) {
 			this.ruleRow();
 			this.ruleCol();
 			this.ruleMain();
-			this.publisherList = {};
+
 			// destory old view
 			Backbone.trigger('event:colsPanelContainer:destroy');
 			Backbone.trigger('event:rowsPanelContainer:destroy');
@@ -388,17 +388,7 @@ define(function(require) {
 					publisherName: 'mainContainer',
 					behavior: 'scrollToPosition', //it's self behavior
 					action: 'verticalPublish' //publisher behavior
-				}, 
-				// {
-				// 	publisherName: 'mainContainer',
-				// 	behavior: 'addHeadItemView', //it's self behavior
-				// 	action: 'addRowHeadItemViewPublish' //publisher behavior
-				// }, {
-				// 	publisherName: 'mainContainer',
-				// 	behavior: 'adjustHeadItemContainer', //it's self behavior
-				// 	action: 'adjustHeadItemContainerPublish' //publisher behavior
-				// }
-				]
+				}]
 			};
 			if (cache.TempProp.isFrozen && cache.TempProp.rowFrozen) {
 				tempRule.displayPosition.offsetTop -= userViewModel.get('top');

--- a/js/views/cellContainer.js
+++ b/js/views/cellContainer.js
@@ -73,6 +73,7 @@ define(function(require) {
 			this.listenTo(this.model, 'change:wordWrap', this.changeWordWrap);
 
 			this.currentRule = options.currentRule;
+			
 			if (cache.TempProp.isFrozen !== true ||
 				this.currentRule.displayPosition.endRowIndex === undefined) {
 				this.listenTo(this.model, 'change:showState', this.destroy);

--- a/js/views/cellsContainer.js
+++ b/js/views/cellsContainer.js
@@ -189,7 +189,9 @@ define(function(require) {
 		 * 自适应高度
 		 */
 		adaptHeight: function() {
-			var height = 0,
+			var userViewTop = this.userViewTop,
+				offsetTop = this.offsetTop,
+				height = 0,
 				top = 0,
 				len, i;
 
@@ -201,7 +203,7 @@ define(function(require) {
 					break;
 				}
 			}
-			this.$el.css('height', top + height);
+			this.$el.css('height', top + height - userViewTop - offsetTop);
 		},
 		/**
 		 * 设置当前鼠标操作状态
@@ -599,6 +601,7 @@ define(function(require) {
 			Backbone.off('event:cellsContainer:destroy');
 			Backbone.off('event:cellsContainer:adaptWidth');
 			Backbone.off('event:cellsContainer:adaptHeight');
+			Backbone.trigger('event:contentCellsContainer:destroy');
 			//待修改：需要销毁包含视图
 			selectModelList = selectRegions.models;
 			len = selectModelList.length;

--- a/js/views/contentCellsContainer.js
+++ b/js/views/contentCellsContainer.js
@@ -89,10 +89,10 @@ define(function(require) {
 			cache.CellsPosition.strandX = {};
 			cache.CellsPosition.strandY = {};
 			cache.cellRegionPosi.vertical = [];
+			cells.reset();
 			top = cache.viewRegion.top;
 			bottom = cache.viewRegion.bottom;
 			this.getCells(top, bottom);
-			loadRecorder.insertPosi(top, bottom, cache.cellRegionPosi.vertical);
 		},
 		restoreHideCellView: function() {
 			var headItemColList = headItemCols.models,
@@ -150,6 +150,7 @@ define(function(require) {
 					data = data.returndata;
 					var cellJSON = data.spreadSheet[0].sheet.cells;
 					original.analysisCellData(cellJSON);
+					loadRecorder.insertPosi(top, bottom, cache.cellRegionPosi.vertical);
 				}
 			});
 		},

--- a/js/views/mainContainer.js
+++ b/js/views/mainContainer.js
@@ -383,7 +383,11 @@ define(function(require) {
 				this.adjustColPropCell(startIndex, endIndex);
 				cache.viewRegion.top = headItemRowList[startIndex].get('top');
 			}
-
+			/**
+			 * 重新渲染超出区域被删除单元格，行列
+			 * @param  {number} top    
+			 * @param  {number} bottom
+			 */
 			function restoreCellView(top, bottom) {
 				var tempCells,
 					startIndex,
@@ -541,6 +545,7 @@ define(function(require) {
 			if (isUnloadRows || isUnloadCells) {
 				this.doRequest(top, bottom, isUnloadRows, isUnloadCells, restoreRowView, restoreCellView);
 			} else {
+				//不需请求数据，直接进行视图还原
 				restoreRowView.call(this, top, bottom);
 				restoreCellView.call(this, top, bottom);
 			}

--- a/js/views/mainContainer.js
+++ b/js/views/mainContainer.js
@@ -120,89 +120,88 @@ define(function(require) {
 		/**
 		 * 生成白色背景，用于遮挡输入框
 		 */
-		addBackGround: function() {
+		addBackGround: function(cellsContainer) {
 			if (this.currentRule.displayPosition.endColAlias !== undefined &&
 				this.currentRule.displayPosition.endRowAlias !== undefined) {
 				//修改为模板
 				this.$el.append('<div style="position:absolute;width:inherit;height:inherit;background-color:white;top:0;left:0;z-index:13"></div>');
-				this.cellsContainer.$el.css({
+				cellsContainer.$el.css({
 					'z-index': '14'
 				});
 			} else if (this.currentRule.displayPosition.endColAlias !== undefined ||
 				this.currentRule.displayPosition.endRowAlias !== undefined) {
 				this.$el.append('<div style="position:absolute;width:inherit;height:inherit;background-color:white;top:0;left:0;z-index:10"></div>');
-				this.cellsContainer.$el.css({
+				cellsContainer.$el.css({
 					'z-index': '11'
 				});
 			}
 		},
-		addCellViewPublish: function(cellModel) {
-			this.publish(cellModel, 'addCellViewPublish');
-		},
+		// addCellViewPublish: function(cellModel) {
+		// 	this.publish(cellModel, 'addCellViewPublish');
+		// },
 
-		addRowHeadItemViewPublish: function(headItemRowModel) {
-			this.publish(headItemRowModel, 'addRowHeadItemViewPublish');
-		},
-		addHeadItemView: function(headItemRowModel) {
-			var startRowIndex = this.currentRule.displayPosition.startRowIndex,
-				endRowIndex = this.currentRule.displayPosition.endRowIndex,
-				headItemRowList = headItemRows.models,
-				gridLineRowContainer;
+		// addRowHeadItemViewPublish: function(headItemRowModel) {
+		// 	this.publish(headItemRowModel, 'addRowHeadItemViewPublish');
+		// },
+		// addHeadItemView: function(headItemRowModel) {
+		// 	var startRowIndex = this.currentRule.displayPosition.startRowIndex,
+		// 		endRowIndex = this.currentRule.displayPosition.endRowIndex,
+		// 		headItemRowList = headItemRows.models,
+		// 		gridLineRowContainer;
 
-			if (headItemRowModel.get('top') < headItemRowList[startRowIndex].get('top') ||
-				(typeof endRowIndex === 'number' && headItemRowModel.get('top') > headItemRowList[endRowIndex].get('top'))) {
-				return;
-			}
-			gridLineRowContainer = new GridLineRowContainer({
-				model: headItemRowModel,
-				frozenTop: this.currentRule.displayPosition.offsetTop
-			});
-			this.cellsContainer.gridLineContainer.rowsGridContainer.$el.append(gridLineRowContainer.render().el);
-		},
-		addCellView: function(cellModel) {
-			var startRowIndex = this.currentRule.displayPosition.startRowIndex,
-				endRowIndex = this.currentRule.displayPosition.endRowIndex,
-				startColIndex = this.currentRule.displayPosition.startColIndex,
-				endColIndex = this.currentRule.displayPosition.endColIndex,
-				tempView,
-				left,
-				right,
-				bottom,
-				top;
+		// 	if (headItemRowModel.get('top') < headItemRowList[startRowIndex].get('top') ||
+		// 		(typeof endRowIndex === 'number' && headItemRowModel.get('top') > headItemRowList[endRowIndex].get('top'))) {
+		// 		return;
+		// 	}
+		// 	gridLineRowContainer = new GridLineRowContainer({
+		// 		model: headItemRowModel,
+		// 		frozenTop: this.currentRule.displayPosition.offsetTop
+		// 	});
+		// 	this.cellsContainer.gridLineContainer.rowsGridContainer.$el.append(gridLineRowContainer.render().el);
+		// },
+		// addCellView: function(cellModel) {
+		// 	var startRowIndex = this.currentRule.displayPosition.startRowIndex,
+		// 		endRowIndex = this.currentRule.displayPosition.endRowIndex,
+		// 		startColIndex = this.currentRule.displayPosition.startColIndex,
+		// 		endColIndex = this.currentRule.displayPosition.endColIndex,
+		// 		tempView,
+		// 		left,
+		// 		right,
+		// 		bottom,
+		// 		top;
 
-			top = cellModel.get('physicsBox').top;
-			bottom = cellModel.get('physicsBox').top + cellModel.get('physicsBox').height;
-			left = cellModel.get('physicsBox').left;
-			right = cellModel.get('physicsBox').left + cellModel.get('physicsBox').width;
+		// 	top = cellModel.get('physicsBox').top;
+		// 	bottom = cellModel.get('physicsBox').top + cellModel.get('physicsBox').height;
+		// 	left = cellModel.get('physicsBox').left;
+		// 	right = cellModel.get('physicsBox').left + cellModel.get('physicsBox').width;
 
-			if (bottom < headItemRowList[startRowIndex].get('top') ||
-				(typeof endRowIndex === 'number' && top > headItemRowList[endRowIndex].get('top')) ||
-				right < headItemColList[startColIndex].get('left') ||
-				(typeof endColIndex === 'number' && left > headItemColList[endColIndex].get('left'))) {
-				return;
-			}
-			tempView = new CellContainer({
-				model: cellModel,
-				currentRule: this.currentRule
-			});
-			this.cellsContainer.contentCellsContainer.$el.prepend(tempView.render().el);
-		},
+		// 	if (bottom < headItemRowList[startRowIndex].get('top') ||
+		// 		(typeof endRowIndex === 'number' && top > headItemRowList[endRowIndex].get('top')) ||
+		// 		right < headItemColList[startColIndex].get('left') ||
+		// 		(typeof endColIndex === 'number' && left > headItemColList[endColIndex].get('left'))) {
+		// 		return;
+		// 	}
+		// 	tempView = new CellContainer({
+		// 		model: cellModel,
+		// 		currentRule: this.currentRule
+		// 	});
+		// 	this.cellsContainer.contentCellsContainer.$el.prepend(tempView.render().el);
+		// },
 		/**
 		 * 页面渲染方法
 		 * @method render
 		 */
 		render: function() {
 			this.attributesRender(this.boxAttributes);
-
-			this.cellsContainer = new CellsContainer({
+			var cellsContainer = new CellsContainer({
 				boxAttributes: {
 					height: this.boxModel.height,
 					width: this.boxModel.width
 				},
 				parentView: this
 			});
-			this.$el.append(this.cellsContainer.render().el);
-			this.addBackGround();
+			this.$el.append(cellsContainer.render().el);
+			this.addBackGround(cellsContainer);
 			this.triggerCallback();
 			return this;
 		},
@@ -428,8 +427,9 @@ define(function(require) {
 				if (headItemRowModel.get('isView') === false) {
 					headItemRowModel.set('isView', true);
 					//待修改，应该将订阅者设置为需要视图还原的容器，不应该为maincontainer
-					this.addHeadItemView(headItemRowModel);
-					this.addRowHeadItemViewPublish(headItemRowModel);
+					// this.addHeadItemView(headItemRowModel);
+					// this.addRowHeadItemViewPublish(headItemRowModel);
+					this.publish('mainContainer', 'restoreRowView', headItemRowModel);
 				}
 			}
 			// when mouse fast moving , we has prevent infinite scroll , the double value will be equal.
@@ -438,8 +438,9 @@ define(function(require) {
 				for (i = 0, len = tempCells.length; i < len; i++) {
 					if (tempCells[i].get('showState') === false) {
 						tempCells[i].set('showState', true);
-						this.addCellView(tempCells[i]);
-						this.addCellViewPublish(tempCells[i]);
+						// this.addCellView(tempCells[i]);
+						// this.addCellViewPublish(tempCells[i]);
+						this.publish('mainContainer', 'restoreCellView', tempCells[i]);
 					}
 				}
 			}
@@ -483,7 +484,7 @@ define(function(require) {
 			}
 			cache.viewRegion.bottom = headItemRowList[limitIndex].get('top') + headItemRowList[limitIndex].get('height');
 		},
-		
+
 		/**
 		 * 显示行下方到达加载区域，添加视图视图
 		 * @method addBottom
@@ -675,14 +676,14 @@ define(function(require) {
 					this.el.scrollLeft = this.recordScrollLeft;
 				} else {
 					this.recordScrollLeft = this.el.scrollLeft;
-					this.publish(this.recordScrollLeft, 'transversePublish');
+					this.publish('mainContainer', 'transversePublish', this.recordScrollLeft);
 				}
 
 				if (distanceBottom >= 0 || distanceTop <= 0) {
 					this.el.scrollTop = this.recordScrollTop;
 				} else {
 					this.recordScrollTop = this.el.scrollTop;
-					this.publish(this.recordScrollTop, 'verticalPublish');
+					this.publish('mainContainer', 'verticalPublish', this.recordScrollTop);
 				}
 			}
 			//did'nt prevent scoll and ensure it's main area ,
@@ -731,29 +732,29 @@ define(function(require) {
 		 * 动态加载，添加列
 		 * @method addCol
 		 */
-		addCol: function() {
-			var len, colValue, i = 0;
+		// addCol: function() {
+		// var len, colValue, i = 0;
 
-			len = config.User.addCol;
-			colValue = headItemCols.length;
-			while (i < len) {
-				headItemCols.add({
-					alias: (colValue + 1).toString(),
-					left: colValue * config.User.cellWidth,
-					width: config.User.cellWidth - 1,
-					displayName: buildAlias.buildColAlias(colValue)
-				});
-				colValue++;
-				i++;
-			}
-			this.cellsContainer.attributesRender({
-				width: headItemCols.getMaxDistanceWidth(),
-				height: headItemRows.getMaxDistanceHeight()
-			});
-			this.viewColsAllHeadContainer.$el.css({
-				width: headItemCols.getMaxDistanceWidth()
-			});
-		},
+		// len = config.User.addCol;
+		// colValue = headItemCols.length;
+		// while (i < len) {
+		// 	headItemCols.add({
+		// 		alias: (colValue + 1).toString(),
+		// 		left: colValue * config.User.cellWidth,
+		// 		width: config.User.cellWidth - 1,
+		// 		displayName: buildAlias.buildColAlias(colValue)
+		// 	});
+		// 	colValue++;
+		// 	i++;
+		// }
+		// this.cellsContainer.attributesRender({
+		// 	width: headItemCols.getMaxDistanceWidth(),
+		// 	height: headItemRows.getMaxDistanceHeight()
+		// });
+		// this.viewColsAllHeadContainer.$el.css({
+		// 	width: headItemCols.getMaxDistanceWidth()
+		// });
+		// },
 		addRows: function(height) {
 			var maxheadItemHeight = headItemRows.getMaxDistanceHeight(),
 				maxLocalHeight = cache.localRowPosi,

--- a/js/views/mainContainer.js
+++ b/js/views/mainContainer.js
@@ -163,8 +163,6 @@ define(function(require) {
 				endRowIndex = this.currentRule.displayPosition.endRowIndex,
 				startColIndex = this.currentRule.displayPosition.startColIndex,
 				endColIndex = this.currentRule.displayPosition.endColIndex,
-				headItemRowList = headItemRows.models,
-				headItemColList = headItemCols.models,
 				tempView,
 				left,
 				right,
@@ -418,8 +416,9 @@ define(function(require) {
 			limitTopPosi = limitTopPosi < 0 ? 0 : limitTopPosi;
 			limitBottomPosi = this.el.scrollTop + this.el.offsetHeight + config.System.prestrainHeight + offsetTop + userViewTop;
 			recordTop = recordTop < limitBottomPosi ? recordTop : limitBottomPosi;
+			
 			//向后台请求数据
-			this.loadRegion(limitTopPosi, recordTop);
+			// this.loadRegion(limitTopPosi, recordTop);
 			limitTopIndex = binary.indexModelBinary(limitTopPosi, headItemRowList, 'top', 'height');
 			recordIndex = binary.indexModelBinary(recordTop, headItemRowList, 'top', 'height');
 

--- a/js/views/mainContainer.js
+++ b/js/views/mainContainer.js
@@ -111,7 +111,7 @@ define(function(require) {
 				cache.viewRegion.bottom = modelLastHeadLineRow.get('top') + modelLastHeadLineRow.get('height');
 				cache.viewRegion.scrollTop = 0;
 				cache.viewRegion.scrollLeft = 0;
-				this.loadState = 'FULFILL';
+				this.loadRowState = 'FULFILL';
 			} else {
 				Backbone.on('event:mainContainer:appointPosition', this.appointPosition, this);
 			}
@@ -398,10 +398,10 @@ define(function(require) {
 				userViewTop,
 				i, len;
 
-			if (this.loadState === 'PENDING') {
+			if (this.loadRowState === 'PENDING') {
 				return;
 			}
-			
+
 			offsetTop = this.offsetTop;
 			userViewTop = this.userViewTop;
 
@@ -433,7 +433,7 @@ define(function(require) {
 				offsetTop,
 				userViewTop;
 
-			if (this.loadState === 'PENDING') {
+			if (this.loadRowState === 'PENDING') {
 				return;
 			}
 
@@ -508,6 +508,7 @@ define(function(require) {
 
 			isUnloadRows = loadRecorder.isUnloadPosi(top, bottom, cache.rowRegionPosi);
 			isUnloadCells = loadRecorder.isUnloadPosi(top, bottom, cache.cellRegionPosi.vertical);
+			
 			//需要根据方向，进行添加缓冲区
 			if (isUnloadRows || isUnloadCells) {
 				bottom = bottom + cache.scrollBufferHeight;
@@ -519,7 +520,10 @@ define(function(require) {
 		doRequest: function(top, bottom, loadRows, loadCells, fn) {
 			var self = this;
 
-			this.loadState = 'PENDING';
+			if (loadRows) {
+				this.loadRowState = 'PENDING';
+			}
+
 
 			send.PackAjax({
 				url: config.url.sheet.load,
@@ -533,7 +537,6 @@ define(function(require) {
 			});
 
 			function analysisData(data) {
-
 				if (!data) {
 					return;
 				}
@@ -557,6 +560,7 @@ define(function(require) {
 
 					loadRecorder.insertPosi(top, bottom, cache.rowRegionPosi);
 					fn.call(self, top, bottom);
+					self.loadRowState = 'FULFILL';
 				}
 				if (loadCells) {
 					var cells = data.returndata.spreadSheet[0].sheet.cells;
@@ -566,7 +570,7 @@ define(function(require) {
 					loadRecorder.insertPosi(headItemRowList[topIndex].get('top'),
 						headItemRowList[bottomIndex].get('top') + headItemRowList[bottomIndex].get('height'), cache.cellRegionPosi.vertical);
 				}
-				self.loadState = 'FULFILL';
+				
 			}
 		},
 		/**

--- a/js/views/mainContainer.js
+++ b/js/views/mainContainer.js
@@ -191,7 +191,7 @@ define(function(require) {
 		 * 页面渲染方法
 		 * @method render
 		 */
-			render: function() {
+		render: function() {
 			this.attributesRender(this.boxAttributes);
 
 			this.cellsContainer = new CellsContainer({
@@ -417,7 +417,7 @@ define(function(require) {
 			limitTopPosi = limitTopPosi < 0 ? 0 : limitTopPosi;
 			limitBottomPosi = this.el.scrollTop + this.el.offsetHeight + config.System.prestrainHeight + offsetTop + userViewTop;
 			recordTop = recordTop < limitBottomPosi ? recordTop : limitBottomPosi;
-			
+
 			//向后台请求数据
 			// this.loadRegion(limitTopPosi, recordTop);
 			limitTopIndex = binary.indexModelBinary(limitTopPosi, headItemRowList, 'top', 'height');
@@ -483,14 +483,13 @@ define(function(require) {
 			}
 			cache.viewRegion.bottom = headItemRowList[limitIndex].get('top') + headItemRowList[limitIndex].get('height');
 		},
-
+		
 		/**
 		 * 显示行下方到达加载区域，添加视图视图
 		 * @method addBottom
 		 */
 		addBottom: function(recordPosi) {
-			var headItemRowList = headItemRows.models,
-				limitTopPosi,
+			var limitTopPosi,
 				limitBottomPosi,
 				limitBottomIndex,
 				recordIndex,

--- a/js/views/rowsAllHeadContainer.js
+++ b/js/views/rowsAllHeadContainer.js
@@ -37,6 +37,15 @@ define(function(require) {
 			Backbone.on('call:rowsAllHeadContainer', this.callRowsAllHeadContainer, this);
 			Backbone.on('event:rowsAllHeadContainer:adaptHeight', this.adaptHeight, this);
 			this.currentRule = clone.clone(cache.CurrentRule);
+
+			//记录冻结情况下导致视图移动大小
+			if (cache.TempProp.isFrozen === true) {
+				this.userViewTop = headItemRows.getModelByAlias(cache.UserView.rowAlias).get('top');
+				this.offsetTop = this.currentRule.displayPosition.offsetTop;
+			} else {
+				this.userViewTop = 0;
+				this.offsetTop = 0;
+			}
 			this.listenTo(siderLineRows, 'add', this.addSiderLineRow);
 			this.boxAttributes = options.boxAttributes;
 		},
@@ -47,11 +56,12 @@ define(function(require) {
 		render: function() {
 			var modelSiderLineRowList = siderLineRows.models,
 				len = modelSiderLineRowList.length,
-				i;
+				rowsHeadContainer, i;
 
-			this.rowsHeadContainer = new RowsHeadContainer();
+			rowsHeadContainer = new RowsHeadContainer();
+
 			this.attributesRender(this.boxAttributes);
-			this.$el.append(this.rowsHeadContainer.render().el);
+			this.$el.append(rowsHeadContainer.render().el);
 			if (len === 0) {
 				this.createSiderLineRow();
 			} else {
@@ -75,8 +85,8 @@ define(function(require) {
 					top = headItemRowList[i].get('top') + headItemRowList[i].get('height');
 					bottom = headItemRowList[start].get('top');
 					this.$el.css({
-						'height': top - bottom
-					});
+						'height': top - bottom - this.userViewTop
+					}); 
 					break;
 				}
 			}
@@ -128,9 +138,9 @@ define(function(require) {
 		 * @method destroy
 		 */
 		destroy: function() {
+			Backbone.trigger('event:rowsHeadContainer:destroy');
 			Backbone.off('call:rowsAllHeadContainer');
 			this.siderLineRowContainer.destroy();
-			this.rowsHeadContainer.destroy();
 			this.remove();
 		}
 	});

--- a/js/views/rowsGridContainer.js
+++ b/js/views/rowsGridContainer.js
@@ -3,6 +3,7 @@ define(function(require) {
 	var $ = require('lib/jquery'),
 		_ = require('lib/underscore'),
 		Backbone = require('lib/backbone'),
+		observerPattern = require('basic/util/observer.pattern'),
 		config = require('spreadsheet/config'),
 		cache = require('basic/tools/cache'),
 		headItemRows = require('collections/headItemRow'),
@@ -35,8 +36,12 @@ define(function(require) {
 			 */
 			this.rowNumber = 0;
 			this.currentRule = cache.CurrentRule;
-			if (cache.TempProp.isFrozen !== true || this.currentRule.displayPosition.endRowIndex === undefined) {
+			if (this.currentRule.displayPosition.endRowIndex === undefined) {
 				this.listenTo(headItemRows, 'add', this.addGridLineRow);
+
+				//订阅滚动行视图还原
+				observerPattern.buildSubscriber(this);
+				this.subscribe('mainContainer', 'restoreRowView', 'restoreRowView');
 			}
 			Backbone.on('call:rowsGridContainer', this.rowsGridContainer, this);
 		},
@@ -67,6 +72,9 @@ define(function(require) {
 				this.rowNumber++;
 			}
 			return this;
+		},
+		restoreRowView: function(model) {
+			this.addGridLineRow(model);
 		},
 		/**
 		 * 渲染view，增加行在`grid`区域内


### PR DESCRIPTION
### 订阅模式：
原订阅模式：记录订阅者数组，订阅方法都绑定在发布者上，所以，进行订阅时，必须含有发布者的引用，造成了视图的引用问题。
**例如**：滚动时，还原行视图，该动作应该由行视图的父级进行订阅，而代码中由maincontainer订阅，然后使用使用的嵌套，进行视图的还原
``` javascript
this.cellsContainer.gridLineContainer.rowsGridContainer.$el.append(gridLineRowContainer.render().el);
```
现订阅模式：记录订阅者数组放到一个类似cache的公共变量中，订阅者通过字符串标识，进行订阅，发布者也通过字符串标识，进行发布

### 异步操作：
         请求行和单元格数据，改为异步操作
         对于行视图/单元格视图还原操作，容器高度的调整操作，作为回调在请求数据成功后执行

- 删除了超出区域阻止自动滚动代码

### 遗留问题：
- 由于存在重新重置所有单元格，导致单元格与行数据请求分开操作，代码相对比较复杂，后期考虑是否能够删除单元格重置功能

- 如果操作过快，导致后台回复数据速度较慢，后期应该对滚动操作的速度，进行限制，避免请求因为超时失败，后期可以在添加非起始点还原功能时，做修改
