### PR TITLE
fix(core-sheet): 行视图滚动删除后，再进行滚动还原，行视图数据容器的顺序

### DIFF
--- a/js/views/mainContainer.js
+++ b/js/views/mainContainer.js
@@ -383,11 +383,11 @@ define(function(require) {
 
 				startIndex = binary.indexModelBinary(top, headItemRowList, 'top', 'height');
 				endIndex = binary.indexModelBinary(bottom, headItemRowList, 'top', 'height');
-				for (i = startIndex; i <= endIndex; i++) {
+				for (i = endIndex; i >= startIndex; i--) {
 					headItemRowModel = headItemRowList[i];
 					if (headItemRowModel.get('isView') === false) {
 						headItemRowModel.set('isView', true);
-						self.publish('mainContainer', 'restoreRowView', headItemRowModel);
+						self.publish('mainContainer', 'restoreRowView', headItemRowModel, 'up');
 					}
 				}
 				self.adjustColPropCell(startIndex, endIndex);
@@ -506,7 +506,7 @@ define(function(require) {
 					headItemRowModel = headItemRowList[i];
 					if (headItemRowModel.get('isView') === false) {
 						headItemRowModel.set('isView', true);
-						self.publish('mainContainer', 'restoreRowView', headItemRowModel);
+						self.publish('mainContainer', 'restoreRowView', headItemRowModel,'down');
 					}
 				}
 				self.adjustColPropCell(startIndex, endIndex);

--- a/js/views/rowsGridContainer.js
+++ b/js/views/rowsGridContainer.js
@@ -73,22 +73,26 @@ define(function(require) {
 			}
 			return this;
 		},
-		restoreRowView: function(model) {
-			this.addGridLineRow(model);
+		restoreRowView: function(model, direction) {
+			this.addGridLineRow(model, direction);
 		},
 		/**
 		 * 渲染view，增加行在`grid`区域内
 		 * @method addGridLineRow
 		 * @param  {object} modelGridLineRow 行model对象
 		 */
-		addGridLineRow: function(modelGridLineRow) {
+		addGridLineRow: function(modelGridLineRow, direction) {
 			//处理冻结状态
 			var gridLineRow = new GridLineRowContainer({
 				model: modelGridLineRow,
 				frozenTop: this.currentRule.displayPosition.offsetTop,
 				endIndex: this.currentRule.displayPosition.endRowIndex
 			});
-			this.$el.append(gridLineRow.render().el);
+			if (direction !== 'down') {
+				this.$el.append(gridLineRow.render().el);
+			} else {
+				this.$el.prepend(gridLineRow.render().el);
+			}
 		},
 
 		/**

--- a/js/views/rowsHeadContainer.js
+++ b/js/views/rowsHeadContainer.js
@@ -86,7 +86,7 @@ define(function(require) {
 			}
 			len = modelsHeadLineRowRegionList.length;
 			for (; i < len; i++) {
-				this.addRowsHeadContainer(modelsHeadLineRowRegionList[i], true);
+				this.addRowsHeadContainer(modelsHeadLineRowRegionList[i]);
 				this.rowNumber++;
 			}
 			//ensure y or n has exist active model,
@@ -280,7 +280,7 @@ define(function(require) {
 		 * 滚动过程中,还原行视图
 		 * @return {[type]} [description]
 		 */
-		restoreRowView: function(model) {
+		restoreRowView: function(model, direction) {
 			var endIndex = this.currentRule.displayPosition.endIndex,
 				startIndex = this.currentRule.displayPosition.startIndex,
 				headItemRowList = headItemRows.models,
@@ -299,22 +299,21 @@ define(function(require) {
 					}
 				}
 			}
-			this.addRowsHeadContainer(model);
+			this.addRowsHeadContainer(model, direction);
 		},
 		/**
 		 * 添加列标视图
 		 * @method addRowsHeadContainer
 		 * @param {app.Models.LineRow} modelHeadItemRow 
 		 */
-		addRowsHeadContainer: function(modelHeadItemRow, initialize) {
+		addRowsHeadContainer: function(modelHeadItemRow, direction) {
 			this.headItemRowContainer = new HeadItemRowContainer({
 				model: modelHeadItemRow,
 				frozenTop: this.currentRule.displayPosition.offsetTop,
 				reduceUserView: this.currentRule.reduceUserView,
 				endIndex: this.currentRule.displayPosition.endIndex
 			});
-			// if (initialize === true || modelHeadItemRow.get('top') > config.displayRowHeight) {
-			if (initialize === true || modelHeadItemRow.get('top')) {
+			if (direction !== 'up') {
 				this.$el.append(this.headItemRowContainer.render().el);
 			} else {
 				this.$el.prepend(this.headItemRowContainer.render().el);


### PR DESCRIPTION
修正了行视图滚动删除后，再进行滚动还原，行视图位于容器的顺序

fixes #249

