### PR TITLE
fix(core-sheet): 粘贴、剪切时背景增加颜色，方便用户定位操作区域

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -52,7 +52,8 @@ textarea { resize: none; overflow: hidden; }
 .content-list .item { position: absolute; overflow: hidden; cursor: default; border: 1px solid transparent; font-size: inherit; font-family: inherit; }
 .content-list .item .bg { height: inherit; width: inherit; }
 .selected-container, .datasource-container, .clip-container { position: absolute; margin: -1px; overflow: hidden; }
-.datasource-container, .clip-container { border: 2px dotted #000; }
+.datasource-container, .clip-container { border: 2px dashed #217346; }
+.datasource-container .box, .clip-container .box { background: #ddd; height: inherit; opacity: 0.35; }
 .selected-container { border: 2px solid #217346; }
 .selected-container .box { position: relative; height: inherit; }
 .selected-container .box .bg { background: #141414; opacity: .24; height: 100%; }


### PR DESCRIPTION
在操作区域内增加背景颜色，当用户操作时更为显眼。同时边框颜色改变为绿色跟项目选中区域效果统一

![1](https://user-images.githubusercontent.com/5516398/27210154-01d1e772-5283-11e7-8ffc-13a827cb1397.png)

