### PR TITLE
fix(core-cell): 输入文本内容无法回退

### DIFF
--- a/js/views/inputContainer.js
+++ b/js/views/inputContainer.js
@@ -231,7 +231,7 @@ define(function(require) {
 				originalText = model.get('content').texts;
 				text = this.$el.val();
 				if (originalText !== text) {
-					history.addUpdateAction('content', text, {
+					history.addUpdateAction('content.texts', text, {
 						startColSort: colSort,
 						startRowSort: rowSort,
 						endColSort: colSort,
@@ -654,17 +654,7 @@ define(function(require) {
 		keyHandle: function() {
 			var inputChar,
 				regular;
-			// if (e.ctrlKey === true || e.altKey === true) {
-			// 	return false;
-			// }
-			// console.log(this.$el);
-			// charcode = typeof e.charCode == 'number' ? e.charCode : e.keyCode;
-			// charcode = e.keyCode;
-			// console.log(e);
-			// console.log(String.fromCharCode(e.which));
-			// inputChar = String.fromCharCode(e.keyCode);
-			// 
-			// console.log(inputChar);
+
 			regular = /[a-zA-Z0-9]/;
 			inputChar = this.$el.val();
 			if (regular.test(inputChar)) {


### PR DESCRIPTION
由于输入文本内容的操作，记录到回退前进模块时，文本属性记录错误 content.texts 错误记录为content 导致回退操作无效，现已修改

