### PR TITLE
fix(core-cell): 解决显示文本中，多个空格合并问题

### DIFF
--- a/js/views/cellContainer.js
+++ b/js/views/cellContainer.js
@@ -382,11 +382,11 @@ define(function(require) {
 			if (modelAttr.wordWrap === true) {
 				this.$contentBody.css({
 					'wordBreak': 'break-word',
-					'whiteSpace': 'normal'
+					'whiteSpace': 'pre-line'
 				});
 			} else {
 				this.$contentBody.css({
-					'whiteSpace': 'nowrap'
+					'whiteSpace': 'pre'
 				});
 			}
 		},


### PR DESCRIPTION
使用white-space属性，解决多个空格在文本中合并问题

fixed #313 